### PR TITLE
Pull in go-quai changes to go-quai v0.28.2

### DIFF
--- a/cmd/utils/cmd.go
+++ b/cmd/utils/cmd.go
@@ -9,7 +9,6 @@ import (
 	"sync"
 
 	"github.com/dominant-strategies/go-quai/common"
-	"github.com/dominant-strategies/go-quai/core/vm"
 	"github.com/dominant-strategies/go-quai/internal/quaiapi"
 	"github.com/dominant-strategies/go-quai/log"
 	"github.com/dominant-strategies/go-quai/metrics_config"
@@ -95,11 +94,6 @@ func makeConfigNode(nodeLocation common.Location, logger *logrus.Logger) (*node.
 		cfg.Quaistats.URL = viper.GetString(QuaiStatsURLFlag.Name)
 	}
 
-	nodeCtx := nodeLocation.Context()
-	// Onlt initialize the precompile for the zone chain
-	if nodeCtx == common.ZONE_CTX {
-		vm.InitializePrecompiles(nodeLocation)
-	}
 	return stack, cfg
 }
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -69,7 +69,6 @@ var NodeFlags = []Flag{
 	DevPeriodFlag,
 	IdentityFlag,
 	DocRootFlag,
-	GCModeFlag,
 	SnapshotFlag,
 	TxLookupLimitFlag,
 	WhitelistFlag,
@@ -284,12 +283,6 @@ var (
 		Name:  c_NodeFlagPrefix + "docroot",
 		Value: xdg.DataHome,
 		Usage: "Document Root for HTTPClient file scheme" + generateEnvDoc(c_NodeFlagPrefix+"docroot"),
-	}
-
-	GCModeFlag = Flag{
-		Name:  c_NodeFlagPrefix + "gcmode",
-		Value: "full",
-		Usage: `Blockchain garbage collection mode ("full", "archive")` + generateEnvDoc(c_NodeFlagPrefix+"gcmode"),
 	}
 
 	SnapshotFlag = Flag{
@@ -1209,12 +1202,6 @@ func CheckExclusive(args ...interface{}) {
 
 // SetQuaiConfig applies quai-related command line flags to the config.
 func SetQuaiConfig(stack *node.Node, cfg *quaiconfig.Config, nodeLocation common.Location, logger *logrus.Logger) {
-	if viper.GetString(GCModeFlag.Name) == "archive" && viper.GetUint64(TxLookupLimitFlag.Name) != 0 {
-		// TODO: see what this is supposed to do
-		viper.IsSet(TxLookupLimitFlag.Name)
-		logger.Warn("Disable transaction unindexing for archive node")
-	}
-
 	cfg.NodeLocation = nodeLocation
 	// only set etherbase if its a zone chain
 	if len(nodeLocation) == 2 {
@@ -1282,12 +1269,6 @@ func SetQuaiConfig(stack *node.Node, cfg *quaiconfig.Config, nodeLocation common
 		cfg.DatabaseFreezer = viper.GetString(AncientDirFlag.Name)
 	}
 
-	if gcmode := viper.GetString(GCModeFlag.Name); gcmode != "full" && gcmode != "archive" {
-		Fatalf("--%s must be either 'full' or 'archive'", GCModeFlag.Name)
-	}
-	if viper.IsSet(GCModeFlag.Name) {
-		cfg.NoPruning = viper.GetString(GCModeFlag.Name) == "archive"
-	}
 	if viper.IsSet(CacheNoPrefetchFlag.Name) {
 		cfg.NoPrefetch = viper.GetBool(CacheNoPrefetchFlag.Name)
 	}

--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -126,9 +126,7 @@ func (v *BlockValidator) ValidateState(block *types.Block, statedb *state.StateD
 	var emittedEtxs types.Transactions
 	for _, receipt := range receipts {
 		if receipt.Status == types.ReceiptStatusSuccessful {
-			for _, etx := range receipt.Etxs {
-				emittedEtxs = append(emittedEtxs, etx)
-			}
+			emittedEtxs = append(emittedEtxs, receipt.Etxs...)
 		}
 	}
 	time6 := common.PrettyDuration(time.Since(start))

--- a/core/bodydb.go
+++ b/core/bodydb.go
@@ -79,6 +79,7 @@ func NewBodyDb(db ethdb.Database, engine consensus.Engine, hc *HeaderChain, chai
 	// only start the state processor in zone
 	if nodeCtx == common.ZONE_CTX && bc.ProcessingState() {
 		bc.processor = NewStateProcessor(chainConfig, hc, engine, vmConfig, cacheConfig, txLookupLimit)
+		vm.InitializePrecompiles(chainConfig.Location)
 	}
 
 	return bc, nil

--- a/core/chain_indexer.go
+++ b/core/chain_indexer.go
@@ -305,7 +305,7 @@ func (c *ChainIndexer) updateLoop(nodeCtx int) {
 						return
 					default:
 					}
-					c.logger.WithField("err", err).Error("Section processing failed")
+					c.logger.WithField("err", err).Warn("Section processing failed")
 				}
 				c.lock.Lock()
 

--- a/core/evm.go
+++ b/core/evm.go
@@ -24,7 +24,6 @@ import (
 	"github.com/dominant-strategies/go-quai/core/types"
 	"github.com/dominant-strategies/go-quai/core/vm"
 	"github.com/dominant-strategies/go-quai/log"
-	"github.com/dominant-strategies/go-quai/params"
 )
 
 // ChainContext supports retrieving headers and consensus parameters from the
@@ -58,7 +57,7 @@ func NewEVMBlockContext(header *types.Header, chain ChainContext, author *common
 	}
 
 	timestamp := header.Time() // base case, should only be the case in genesis block or before forkBlock (in testnet)
-	if header.Number(chain.NodeCtx()).Uint64() != 0 && header.Number(chain.NodeCtx()).Uint64() > params.CarbonForkBlockNumber {
+	if header.Number(chain.NodeCtx()).Uint64() != 0 {
 		parent := chain.GetHeader(header.ParentHash(chain.NodeCtx()), header.Number(chain.NodeCtx()).Uint64()-1)
 		if parent != nil {
 			timestamp = parent.Time()

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -196,14 +196,6 @@ func NewDatabaseWithFreezer(db ethdb.KeyValueStore, freezer string, namespace st
 			// feezer.
 		}
 	}
-	// Freezer is consistent with the key-value database, permit combining the two
-	if !frdb.readonly {
-		frdb.wg.Add(1)
-		go func() {
-			frdb.freeze(db, nodeCtx)
-			frdb.wg.Done()
-		}()
-	}
 	return &freezerdb{
 		KeyValueStore: db,
 		AncientStore:  frdb,

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -243,7 +243,6 @@ func (p *StateProcessor) Process(block *types.Block, etxSet types.EtxSet) (types
 		etxPLimit = params.ETXPLimitMin
 	}
 
-	var emittedEtxs types.Transactions
 	for i, tx := range block.Transactions() {
 		startProcess := time.Now()
 		msg, err := tx.AsMessageWithSender(types.MakeSigner(p.config, header.Number(nodeCtx)), header.BaseFee(), senders[tx.Hash()])
@@ -284,7 +283,6 @@ func (p *StateProcessor) Process(block *types.Block, etxSet types.EtxSet) (types
 			if err != nil {
 				return nil, nil, nil, 0, fmt.Errorf("could not apply tx %d [%v]: %w", i, tx.Hash().Hex(), err)
 			}
-			emittedEtxs = append(emittedEtxs, receipt.Etxs...)
 			timeTxDelta := time.Since(startTimeTx)
 			timeTx += timeTxDelta
 		} else {

--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -42,15 +42,15 @@ type PrecompiledContract interface {
 }
 
 var TranslatedAddresses = map[common.AddressBytes]int{
-	common.AddressBytes([20]byte{1}): 0,
-	common.AddressBytes([20]byte{2}): 1,
-	common.AddressBytes([20]byte{3}): 2,
-	common.AddressBytes([20]byte{4}): 3,
-	common.AddressBytes([20]byte{5}): 4,
-	common.AddressBytes([20]byte{6}): 5,
-	common.AddressBytes([20]byte{7}): 6,
-	common.AddressBytes([20]byte{8}): 7,
-	common.AddressBytes([20]byte{9}): 8,
+	common.AddressBytes(intToByteArray20(1)): 0,
+	common.AddressBytes(intToByteArray20(2)): 1,
+	common.AddressBytes(intToByteArray20(3)): 2,
+	common.AddressBytes(intToByteArray20(4)): 3,
+	common.AddressBytes(intToByteArray20(5)): 4,
+	common.AddressBytes(intToByteArray20(6)): 5,
+	common.AddressBytes(intToByteArray20(7)): 6,
+	common.AddressBytes(intToByteArray20(8)): 7,
+	common.AddressBytes(intToByteArray20(9)): 8,
 }
 
 var (
@@ -593,4 +593,10 @@ func (c *blake2F) Run(input []byte) ([]byte, error) {
 		binary.LittleEndian.PutUint64(output[offset:offset+8], h[i])
 	}
 	return output, nil
+}
+
+func intToByteArray20(n uint8) [20]byte {
+	var byteArray [20]byte
+	byteArray[19] = byte(n) // Use the last byte for the integer
+	return byteArray
 }

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -45,6 +45,9 @@ type (
 )
 
 func (evm *EVM) precompile(addr common.Address) (PrecompiledContract, bool, common.Address) {
+	if evm.Context.BlockNumber.Uint64() <= params.CarbonForkBlockNumber { // no precompiles before the fork
+		return nil, false, addr
+	}
 	if index, ok := TranslatedAddresses[addr.Bytes20()]; ok {
 		addr = PrecompiledAddresses[evm.chainConfig.Location.Name()][index]
 	}

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -17,6 +17,7 @@
 package vm
 
 import (
+	"encoding/binary"
 	"fmt"
 	"math/big"
 	"sync"
@@ -505,8 +506,76 @@ func (evm *EVM) Create(caller ContractRef, code []byte, gas uint64, value *big.I
 	if err != nil {
 		return nil, common.ZeroAddr, 0, err
 	}
-	contractAddr = crypto.CreateAddress(caller.Address(), evm.StateDB.GetNonce(internalAddr), code, evm.chainConfig.Location)
+
+	nonce := evm.StateDB.GetNonce(internalAddr)
+
+	contractAddr = crypto.CreateAddress(caller.Address(), nonce, code, evm.chainConfig.Location)
+	if _, err := contractAddr.InternalAddress(); err == nil {
+		return evm.create(caller, &codeAndHash{code: code}, gas, value, contractAddr)
+	} else if evm.Context.BlockNumber.Uint64() <= params.CarbonForkBlockNumber {
+		return evm.create(caller, &codeAndHash{code: code}, gas, value, contractAddr)
+	}
+
+	// Calculate the gas required for the keccak256 computation of the input data.
+	gasCost, err := calculateKeccakGas(code)
+	if err != nil {
+		return nil, common.ZeroAddr, 0, err
+	}
+
+	// attempt to grind the address
+	contractAddr, remainingGas, err := evm.attemptGrindContractCreation(caller, nonce, gas, gasCost, code)
+	if err != nil {
+		return nil, common.ZeroAddr, 0, err
+	}
+
+	gas = remainingGas
+
 	return evm.create(caller, &codeAndHash{code: code}, gas, value, contractAddr)
+}
+
+// calculateKeccakGas calculates the gas required for performing a keccak256 hash on the given data.
+// It returns the total gas cost and any error that may occur during the calculation.
+func calculateKeccakGas(data []byte) (int64, error) {
+	// Base gas for keccak256 computation.
+	keccakBaseGas := int64(params.Sha3Gas)
+	// Calculate the number of words (rounded up) in the data for gas calculation.
+	wordCount := (len(data) + 31) / 32 // Round up to the nearest word
+	return keccakBaseGas + int64(wordCount)*int64(params.Sha3WordGas), nil
+}
+
+// attemptContractCreation tries to create a contract address by iterating through possible nonce values.
+// It returns the modified data for contract creation and any error encountered.
+func (evm *EVM) attemptGrindContractCreation(caller ContractRef, nonce uint64, gas uint64, gasCost int64, code []byte) (common.Address, uint64, error) {
+	senderAddress := caller.Address()
+
+	codeAndHash := &codeAndHash{code: code}
+	var salt [32]byte
+	binary.BigEndian.PutUint64(salt[24:], nonce)
+
+	// Iterate through possible nonce values to find a suitable contract address.
+	for i := 0; i < params.MaxAddressGrindAttempts; i++ {
+
+		// Check if there is enough gas left to continue.
+		if gas < uint64(gasCost) {
+			return common.ZeroAddr, 0, fmt.Errorf("out of gas grinding contract address for %v", caller.Address().Hex())
+		}
+
+		// Subtract the gas cost for each attempt.
+		gas -= uint64(gasCost)
+
+		// Place i in the [32]byte array.
+		binary.BigEndian.PutUint64(salt[16:24], uint64(i))
+
+		// Generate a potential contract address.
+		contractAddr := crypto.CreateAddress2(senderAddress, salt, codeAndHash.Hash().Bytes(), evm.chainConfig.Location)
+
+		// Check if the generated address is valid.
+		if _, err := contractAddr.InternalAddress(); err == nil {
+			return contractAddr, gas, nil
+		}
+	}
+	// Return an error if a valid address could not be found after the maximum number of attempts.
+	return common.ZeroAddr, 0, fmt.Errorf("exceeded number of attempts grinding address %v", caller.Address().Hex())
 }
 
 // Create2 creates a new contract using code as deployment code.

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -46,9 +46,6 @@ type (
 )
 
 func (evm *EVM) precompile(addr common.Address) (PrecompiledContract, bool, common.Address) {
-	if evm.Context.BlockNumber.Uint64() <= params.CarbonForkBlockNumber { // no precompiles before the fork
-		return nil, false, addr
-	}
 	if index, ok := TranslatedAddresses[addr.Bytes20()]; ok {
 		addr = PrecompiledAddresses[evm.chainConfig.Location.Name()][index]
 	}
@@ -511,8 +508,6 @@ func (evm *EVM) Create(caller ContractRef, code []byte, gas uint64, value *big.I
 
 	contractAddr = crypto.CreateAddress(caller.Address(), nonce, code, evm.chainConfig.Location)
 	if _, err := contractAddr.InternalAddress(); err == nil {
-		return evm.create(caller, &codeAndHash{code: code}, gas, value, contractAddr)
-	} else if evm.Context.BlockNumber.Uint64() <= params.CarbonForkBlockNumber {
 		return evm.create(caller, &codeAndHash{code: code}, gas, value, contractAddr)
 	}
 

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -694,7 +694,7 @@ func opCall(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byt
 	if err == nil || err == ErrExecutionReverted {
 		ret = common.CopyBytes(ret)
 		scope.Memory.Set(retOffset.Uint64(), retSize.Uint64(), ret)
-	} else if err == common.ErrInvalidScope && interpreter.evm.Context.BlockNumber.Uint64() > params.CarbonForkBlockNumber {
+	} else if err == common.ErrInvalidScope {
 		return nil, err
 	}
 	scope.Contract.Gas += returnGas
@@ -711,10 +711,6 @@ func opCallCode(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([
 	// Pop other call parameters.
 	addr, value, inOffset, inSize, retOffset, retSize := stack.pop(), stack.pop(), stack.pop(), stack.pop(), stack.pop(), stack.pop()
 	toAddr := common.Bytes20ToAddress(addr.Bytes20(), interpreter.evm.chainConfig.Location)
-	// Check if address is in proper context
-	if !common.IsInChainScope(toAddr.Bytes(), interpreter.evm.chainConfig.Location) && interpreter.evm.Context.BlockNumber.Uint64() <= params.CarbonForkBlockNumber {
-		return nil, common.ErrInvalidScope
-	}
 	// Get arguments from the memory.
 	args := scope.Memory.GetPtr(int64(inOffset.Uint64()), int64(inSize.Uint64()))
 
@@ -735,7 +731,7 @@ func opCallCode(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([
 	if err == nil || err == ErrExecutionReverted {
 		ret = common.CopyBytes(ret)
 		scope.Memory.Set(retOffset.Uint64(), retSize.Uint64(), ret)
-	} else if err == common.ErrInvalidScope && interpreter.evm.Context.BlockNumber.Uint64() > params.CarbonForkBlockNumber {
+	} else if err == common.ErrInvalidScope {
 		return nil, err
 	}
 	scope.Contract.Gas += returnGas
@@ -752,10 +748,6 @@ func opDelegateCall(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext
 	// Pop other call parameters.
 	addr, inOffset, inSize, retOffset, retSize := stack.pop(), stack.pop(), stack.pop(), stack.pop(), stack.pop()
 	toAddr := common.Bytes20ToAddress(addr.Bytes20(), interpreter.evm.chainConfig.Location)
-	// Check if address is in proper context
-	if !common.IsInChainScope(toAddr.Bytes(), interpreter.evm.chainConfig.Location) && interpreter.evm.Context.BlockNumber.Uint64() <= params.CarbonForkBlockNumber {
-		return nil, common.ErrInvalidScope
-	}
 	// Get arguments from the memory.
 	args := scope.Memory.GetPtr(int64(inOffset.Uint64()), int64(inSize.Uint64()))
 
@@ -769,7 +761,7 @@ func opDelegateCall(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext
 	if err == nil || err == ErrExecutionReverted {
 		ret = common.CopyBytes(ret)
 		scope.Memory.Set(retOffset.Uint64(), retSize.Uint64(), ret)
-	} else if err == common.ErrInvalidScope && interpreter.evm.Context.BlockNumber.Uint64() > params.CarbonForkBlockNumber {
+	} else if err == common.ErrInvalidScope {
 		return nil, err
 	}
 	scope.Contract.Gas += returnGas
@@ -786,10 +778,6 @@ func opStaticCall(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) 
 	// Pop other call parameters.
 	addr, inOffset, inSize, retOffset, retSize := stack.pop(), stack.pop(), stack.pop(), stack.pop(), stack.pop()
 	toAddr := common.Bytes20ToAddress(addr.Bytes20(), interpreter.evm.chainConfig.Location)
-	// Check if address is in proper context
-	if !common.IsInChainScope(toAddr.Bytes(), interpreter.evm.chainConfig.Location) && interpreter.evm.Context.BlockNumber.Uint64() <= params.CarbonForkBlockNumber {
-		return nil, common.ErrInvalidScope
-	}
 	// Get arguments from the memory.
 	args := scope.Memory.GetPtr(int64(inOffset.Uint64()), int64(inSize.Uint64()))
 
@@ -803,7 +791,7 @@ func opStaticCall(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) 
 	if err == nil || err == ErrExecutionReverted {
 		ret = common.CopyBytes(ret)
 		scope.Memory.Set(retOffset.Uint64(), retSize.Uint64(), ret)
-	} else if err == common.ErrInvalidScope && interpreter.evm.Context.BlockNumber.Uint64() > params.CarbonForkBlockNumber {
+	} else if err == common.ErrInvalidScope {
 		return nil, err
 	}
 	scope.Contract.Gas += returnGas

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -694,6 +694,8 @@ func opCall(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byt
 	if err == nil || err == ErrExecutionReverted {
 		ret = common.CopyBytes(ret)
 		scope.Memory.Set(retOffset.Uint64(), retSize.Uint64(), ret)
+	} else if err == common.ErrInvalidScope && interpreter.evm.Context.BlockNumber.Uint64() > params.CarbonForkBlockNumber {
+		return nil, err
 	}
 	scope.Contract.Gas += returnGas
 
@@ -710,7 +712,7 @@ func opCallCode(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([
 	addr, value, inOffset, inSize, retOffset, retSize := stack.pop(), stack.pop(), stack.pop(), stack.pop(), stack.pop(), stack.pop()
 	toAddr := common.Bytes20ToAddress(addr.Bytes20(), interpreter.evm.chainConfig.Location)
 	// Check if address is in proper context
-	if !common.IsInChainScope(toAddr.Bytes(), interpreter.evm.chainConfig.Location) { // checked here because the error returned from CallCode is not returned from this function
+	if !common.IsInChainScope(toAddr.Bytes(), interpreter.evm.chainConfig.Location) && interpreter.evm.Context.BlockNumber.Uint64() <= params.CarbonForkBlockNumber {
 		return nil, common.ErrInvalidScope
 	}
 	// Get arguments from the memory.
@@ -733,6 +735,8 @@ func opCallCode(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([
 	if err == nil || err == ErrExecutionReverted {
 		ret = common.CopyBytes(ret)
 		scope.Memory.Set(retOffset.Uint64(), retSize.Uint64(), ret)
+	} else if err == common.ErrInvalidScope && interpreter.evm.Context.BlockNumber.Uint64() > params.CarbonForkBlockNumber {
+		return nil, err
 	}
 	scope.Contract.Gas += returnGas
 
@@ -749,7 +753,7 @@ func opDelegateCall(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext
 	addr, inOffset, inSize, retOffset, retSize := stack.pop(), stack.pop(), stack.pop(), stack.pop(), stack.pop()
 	toAddr := common.Bytes20ToAddress(addr.Bytes20(), interpreter.evm.chainConfig.Location)
 	// Check if address is in proper context
-	if !common.IsInChainScope(toAddr.Bytes(), interpreter.evm.chainConfig.Location) {
+	if !common.IsInChainScope(toAddr.Bytes(), interpreter.evm.chainConfig.Location) && interpreter.evm.Context.BlockNumber.Uint64() <= params.CarbonForkBlockNumber {
 		return nil, common.ErrInvalidScope
 	}
 	// Get arguments from the memory.
@@ -765,6 +769,8 @@ func opDelegateCall(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext
 	if err == nil || err == ErrExecutionReverted {
 		ret = common.CopyBytes(ret)
 		scope.Memory.Set(retOffset.Uint64(), retSize.Uint64(), ret)
+	} else if err == common.ErrInvalidScope && interpreter.evm.Context.BlockNumber.Uint64() > params.CarbonForkBlockNumber {
+		return nil, err
 	}
 	scope.Contract.Gas += returnGas
 
@@ -781,7 +787,7 @@ func opStaticCall(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) 
 	addr, inOffset, inSize, retOffset, retSize := stack.pop(), stack.pop(), stack.pop(), stack.pop(), stack.pop()
 	toAddr := common.Bytes20ToAddress(addr.Bytes20(), interpreter.evm.chainConfig.Location)
 	// Check if address is in proper context
-	if !common.IsInChainScope(toAddr.Bytes(), interpreter.evm.chainConfig.Location) {
+	if !common.IsInChainScope(toAddr.Bytes(), interpreter.evm.chainConfig.Location) && interpreter.evm.Context.BlockNumber.Uint64() <= params.CarbonForkBlockNumber {
 		return nil, common.ErrInvalidScope
 	}
 	// Get arguments from the memory.
@@ -797,6 +803,8 @@ func opStaticCall(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) 
 	if err == nil || err == ErrExecutionReverted {
 		ret = common.CopyBytes(ret)
 		scope.Memory.Set(retOffset.Uint64(), retSize.Uint64(), ret)
+	} else if err == common.ErrInvalidScope && interpreter.evm.Context.BlockNumber.Uint64() > params.CarbonForkBlockNumber {
+		return nil, err
 	}
 	scope.Contract.Gas += returnGas
 

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -30,6 +30,8 @@ const (
 	GasLimitStepThreeBlockThreshold uint64 = 450000
 	MinGasLimit                     uint64 = 5000000 // Minimum the gas limit may ever be.
 	GenesisGasLimit                 uint64 = 5000000 // Gas limit of the Genesis block.
+	CarbonForkBlockNumber           uint64 = 690000
+	CarbonForkSyncThreshold         uint64 = 100
 
 	MaximumExtraDataSize  uint64 = 32                                                       // Maximum size extra data may be after Genesis.
 	ExpByteGas            uint64 = 10                                                       // Times ceil(log256(exponent)) for the EXP instruction.

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -30,8 +30,6 @@ const (
 	GasLimitStepThreeBlockThreshold uint64 = 450000
 	MinGasLimit                     uint64 = 5000000 // Minimum the gas limit may ever be.
 	GenesisGasLimit                 uint64 = 5000000 // Gas limit of the Genesis block.
-	CarbonForkBlockNumber           uint64 = 690000
-	CarbonForkSyncThreshold         uint64 = 100
 
 	MaximumExtraDataSize  uint64 = 32                                                       // Maximum size extra data may be after Genesis.
 	ExpByteGas            uint64 = 10                                                       // Times ceil(log256(exponent)) for the EXP instruction.

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -140,6 +140,8 @@ const (
 
 	// The Refund Quotient is the cap on how much of the used gas can be refunded
 	RefundQuotient uint64 = 5
+
+	MaxAddressGrindAttempts int = 1000 // Maximum number of attempts to grind an address to a valid one
 )
 
 var (

--- a/quai/backend.go
+++ b/quai/backend.go
@@ -194,7 +194,6 @@ func New(stack *node.Node, p2p NetworkingAPI, config *quaiconfig.Config, nodeCtx
 			TrieCleanRejournal:  config.TrieCleanCacheRejournal,
 			TrieCleanNoPrefetch: config.NoPrefetch,
 			TrieDirtyLimit:      config.TrieDirtyCache,
-			TrieDirtyDisabled:   config.NoPruning,
 			TrieTimeLimit:       config.TrieTimeout,
 			SnapshotLimit:       config.SnapshotCache,
 			Preimages:           config.Preimages,

--- a/quai/backend.go
+++ b/quai/backend.go
@@ -279,7 +279,7 @@ func (s *Quai) APIs() []rpc.API {
 			Service:   NewPrivateMinerAPI(s),
 			Public:    false,
 		}, {
-			Namespace: "eth",
+			Namespace: "quai",
 			Version:   "1.0",
 			Service:   filters.NewPublicFilterAPI(s.APIBackend, 5*time.Minute),
 			Public:    true,

--- a/quai/backend.go
+++ b/quai/backend.go
@@ -279,6 +279,11 @@ func (s *Quai) APIs() []rpc.API {
 			Service:   NewPrivateMinerAPI(s),
 			Public:    false,
 		}, {
+			Namespace: "eth",
+			Version:   "1.0",
+			Service:   filters.NewPublicFilterAPI(s.APIBackend, 5*time.Minute),
+			Public:    true,
+		}, {
 			Namespace: "quai",
 			Version:   "1.0",
 			Service:   filters.NewPublicFilterAPI(s.APIBackend, 5*time.Minute),

--- a/quaiclient/ethclient/ethclient.go
+++ b/quaiclient/ethclient/ethclient.go
@@ -411,7 +411,7 @@ func (ec *Client) FilterLogs(ctx context.Context, q quai.FilterQuery) ([]types.L
 	if err != nil {
 		return nil, err
 	}
-	err = ec.c.CallContext(ctx, &result, "eth_getLogs", arg)
+	err = ec.c.CallContext(ctx, &result, "quai_getLogs", arg)
 	return result, err
 }
 

--- a/quaiclient/ethclient/ethclient.go
+++ b/quaiclient/ethclient/ethclient.go
@@ -402,49 +402,6 @@ func (ec *Client) NonceAt(ctx context.Context, account common.Address, blockNumb
 	return uint64(result), err
 }
 
-// Filters
-
-// FilterLogs executes a filter query.
-func (ec *Client) FilterLogs(ctx context.Context, q quai.FilterQuery) ([]types.Log, error) {
-	var result []types.Log
-	arg, err := toFilterArg(q)
-	if err != nil {
-		return nil, err
-	}
-	err = ec.c.CallContext(ctx, &result, "quai_getLogs", arg)
-	return result, err
-}
-
-// SubscribeFilterLogs subscribes to the results of a streaming filter query.
-func (ec *Client) SubscribeFilterLogs(ctx context.Context, q quai.FilterQuery, ch chan<- types.Log) (quai.Subscription, error) {
-	arg, err := toFilterArg(q)
-	if err != nil {
-		return nil, err
-	}
-	return ec.c.EthSubscribe(ctx, ch, "logs", arg)
-}
-
-func toFilterArg(q quai.FilterQuery) (interface{}, error) {
-	arg := map[string]interface{}{
-		"address": q.Addresses,
-		"topics":  q.Topics,
-	}
-	if q.BlockHash != nil {
-		arg["blockHash"] = *q.BlockHash
-		if q.FromBlock != nil || q.ToBlock != nil {
-			return nil, fmt.Errorf("cannot specify both BlockHash and FromBlock/ToBlock")
-		}
-	} else {
-		if q.FromBlock == nil {
-			arg["fromBlock"] = "0x0"
-		} else {
-			arg["fromBlock"] = toBlockNumArg(q.FromBlock)
-		}
-		arg["toBlock"] = toBlockNumArg(q.ToBlock)
-	}
-	return arg, nil
-}
-
 // Pending State
 
 // PendingBalanceAt returns the wei balance of the given account in the pending state.

--- a/quaiclient/quaiclient.go
+++ b/quaiclient/quaiclient.go
@@ -20,10 +20,13 @@ package quaiclient
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"math/big"
 	"time"
 
+	quai "github.com/dominant-strategies/go-quai"
 	"github.com/dominant-strategies/go-quai/common"
+	"github.com/dominant-strategies/go-quai/common/hexutil"
 	"github.com/dominant-strategies/go-quai/core/types"
 	"github.com/dominant-strategies/go-quai/rpc"
 	"github.com/sirupsen/logrus"
@@ -91,6 +94,11 @@ type appendReturns struct {
 	Etxs     types.Transactions `json:"pendingEtxs"`
 	SubReorg bool               `json:"subReorg"`
 	SetHead  bool               `json:"setHead"`
+}
+
+// SubscribePendingHeader subscribes to notifications about the current pending block on the node.
+func (ec *Client) SubscribePendingHeader(ctx context.Context, ch chan<- *types.Header) (quai.Subscription, error) {
+	return ec.c.QuaiSubscribe(ctx, ch, "pendingHeader")
 }
 
 func (ec *Client) Append(ctx context.Context, header *types.Header, manifest types.BlockManifest, domPendingHeader *types.Header, domTerminus common.Hash, domOrigin bool, newInboundEtxs types.Transactions) (types.Transactions, bool, bool, error) {
@@ -261,4 +269,96 @@ func (ec *Client) HeaderByNumber(ctx context.Context, number string) *types.Head
 func (ec *Client) SetSyncTarget(ctx context.Context, header *types.Header) {
 	fields := header.RPCMarshalHeader()
 	ec.c.CallContext(ctx, nil, "quai_setSyncTarget", fields)
+}
+
+//// Miner APIS
+
+// GetPendingHeader gets the latest pending header from the chain.
+func (ec *Client) GetPendingHeader(ctx context.Context) (*types.Header, error) {
+	var pendingHeader *types.Header
+	err := ec.c.CallContext(ctx, &pendingHeader, "quai_getPendingHeader")
+	if err != nil {
+		return nil, err
+	}
+	return pendingHeader, nil
+}
+
+// ReceiveMinedHeader sends a mined block back to the node
+func (ec *Client) ReceiveMinedHeader(ctx context.Context, header *types.Header) error {
+	data := header.RPCMarshalHeader()
+	return ec.c.CallContext(ctx, nil, "quai_receiveMinedHeader", data)
+}
+
+// Filters
+
+// SubscribeFilterLogs subscribes to the results of a streaming filter query.
+func (ec *Client) SubscribeFilterLogs(ctx context.Context, q quai.FilterQuery, ch chan<- types.Log) (quai.Subscription, error) {
+	arg, err := toFilterArg(q)
+	if err != nil {
+		return nil, err
+	}
+	return ec.c.QuaiSubscribe(ctx, ch, "logs", arg)
+}
+
+func toFilterArg(q quai.FilterQuery) (interface{}, error) {
+	arg := map[string]interface{}{
+		"address": q.Addresses,
+		"topics":  q.Topics,
+	}
+	if q.BlockHash != nil {
+		arg["blockHash"] = *q.BlockHash
+		if q.FromBlock != nil || q.ToBlock != nil {
+			return nil, fmt.Errorf("cannot specify both BlockHash and FromBlock/ToBlock")
+		}
+	} else {
+		if q.FromBlock == nil {
+			arg["fromBlock"] = "0x0"
+		} else {
+			arg["fromBlock"] = toBlockNumArg(q.FromBlock)
+		}
+		arg["toBlock"] = toBlockNumArg(q.ToBlock)
+	}
+	return arg, nil
+}
+
+func toBlockNumArg(number *big.Int) string {
+	if number == nil {
+		return "latest"
+	}
+	pending := big.NewInt(-1)
+	if number.Cmp(pending) == 0 {
+		return "pending"
+	}
+	return hexutil.EncodeBig(number)
+}
+
+func toCallArg(msg quai.CallMsg) interface{} {
+	arg := map[string]interface{}{
+		"from": msg.From,
+		"to":   msg.To,
+	}
+	if len(msg.Data) > 0 {
+		arg["data"] = hexutil.Bytes(msg.Data)
+	}
+	if msg.Value != nil {
+		arg["value"] = (*hexutil.Big)(msg.Value)
+	}
+	if msg.Gas != 0 {
+		arg["gas"] = hexutil.Uint64(msg.Gas)
+	}
+	if msg.GasPrice != nil {
+		arg["gasPrice"] = (*hexutil.Big)(msg.GasPrice)
+	}
+	return arg
+}
+
+// FilterLogs executes a filter query.
+func (ec *Client) FilterLogs(ctx context.Context, q quai.FilterQuery) ([]types.Log, error) {
+	var result []types.Log
+	arg, err := toFilterArg(q)
+	if err != nil {
+		return nil, err
+	}
+	err = ec.c.CallContext(ctx, &result, "quai_getLogs", arg)
+	return result, err
 }

--- a/quaistats/quaistats.go
+++ b/quaistats/quaistats.go
@@ -439,13 +439,25 @@ func (s *Service) loopSender(urlMap map[string]string) {
 					}
 				case <-s.statsReadyCh:
 					if url, ok := urlMap["blockTransactionStats"]; ok {
-						s.sendTransactionStats(url, authJwt)
+						if err := s.sendTransactionStats(url, authJwt); err != nil {
+							noErrs = false
+							errTimer.Reset(0)
+							log.Warn("blockTransactionStats stats report failed", "err", err)
+						}
 					}
 					if url, ok := urlMap["blockDetailStats"]; ok {
-						s.sendDetailStats(url, authJwt)
+						if err := s.sendDetailStats(url, authJwt); err != nil {
+							noErrs = false
+							errTimer.Reset(0)
+							log.Warn("blockDetailStats stats report failed", "err", err)
+						}
 					}
 					if url, ok := urlMap["blockAppendTime"]; ok {
-						s.sendAppendTimeStats(url, authJwt)
+						if err := s.sendAppendTimeStats(url, authJwt); err != nil {
+							noErrs = false
+							errTimer.Reset(0)
+							log.Warn("blockAppendTime stats report failed", "err", err)
+						}
 					}
 				}
 				errTimer.Reset(0)

--- a/quaistats/quaistats.go
+++ b/quaistats/quaistats.go
@@ -171,7 +171,7 @@ func (q *StatsQueue) Enqueue(item interface{}) {
 	defer q.mutex.Unlock()
 
 	if len(q.data) >= c_maxQueueSize {
-		q.Dequeue()
+		q.dequeue()
 	}
 
 	q.data = append(q.data, item)
@@ -185,6 +185,10 @@ func (q *StatsQueue) Dequeue() interface{} {
 		return nil
 	}
 
+	return q.dequeue()
+}
+
+func (q *StatsQueue) dequeue() interface{} {
 	item := q.data[0]
 	q.data = q.data[1:]
 	return item
@@ -195,8 +199,7 @@ func (q *StatsQueue) EnqueueFront(item interface{}) {
 	defer q.mutex.Unlock()
 
 	if len(q.data) >= c_maxQueueSize {
-		// Remove one item from the front (oldest item)
-		q.data = q.data[1:]
+		q.dequeue()
 	}
 
 	q.data = append([]interface{}{item}, q.data...)

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -412,6 +412,11 @@ func (c *Client) EthSubscribe(ctx context.Context, channel interface{}, args ...
 	return c.Subscribe(ctx, "eth", channel, args...)
 }
 
+// QuaiSubscribe registers a subscripion under the "eth" namespace.
+func (c *Client) QuaiSubscribe(ctx context.Context, channel interface{}, args ...interface{}) (*ClientSubscription, error) {
+	return c.Subscribe(ctx, "quai", channel, args...)
+}
+
 // ShhSubscribe registers a subscripion under the "shh" namespace.
 // Deprecated: use Subscribe(ctx, "shh", ...).
 func (c *Client) ShhSubscribe(ctx context.Context, channel interface{}, args ...interface{}) (*ClientSubscription, error) {


### PR DESCRIPTION
Cherry picked commits from go-quai/main

Excluded: 
"Revert 'cleanup of tracer to working'" - https://github.com/dominant-strategies/go-quai/commit/7d9cdeabd62c1d79095ce851a26426948f56566a

"Reapply 'removed tracers'" - https://github.com/dominant-strategies/go-quai/commit/e85f4b199ee5866257fbbc58cd02b2338753d150

Reasoning:
Don't have tracers in libp2p
