### PR TITLE
Coinbase input modification and config generation fix

### DIFF
--- a/cmd/go-quai/start.go
+++ b/cmd/go-quai/start.go
@@ -38,6 +38,10 @@ func init() {
 		utils.CreateAndBindFlag(flag, startCmd)
 	}
 
+	for _, flag := range utils.TXPoolFlags {
+		utils.CreateAndBindFlag(flag, startCmd)
+	}
+
 	// Create and bind all rpc flags to the start command
 	for _, flag := range utils.RPCFlags {
 		utils.CreateAndBindFlag(flag, startCmd)

--- a/common/constants/constants.go
+++ b/common/constants/constants.go
@@ -4,10 +4,12 @@ const (
 	APP_NAME = "go-quai"
 	// prefix used to read config parameters from environment variables
 	ENV_PREFIX = "GO_QUAI"
-	// default private key file name
+	// private key file name
 	PRIVATE_KEY_FILENAME = "private.key"
-	// default config file name
-	CONFIG_FILE_NAME = "config.yaml"
+	// config file name
+	CONFIG_FILE_NAME = "config.toml"
+	// config file type
+	CONFIG_FILE_TYPE = "toml"
 	// file to dynamically store node's ID and listening addresses
 	NODEINFO_FILE_NAME = "node.info"
 	// file to read the host's IP address (used to replace Docker's internal IP)


### PR DESCRIPTION
**Changes**:

Coinbases:
1. Coinbases are passed in as a list "0x123, 0x421" etc and node figures out what shared they are for based on QIP-2
2. No longer need to specify a coinbase address to run node


Config:
1. config.toml will be generated on first run with all default flag values based on `--global.config-dir` flag (Defaults to XDG config directory)
2. Flags are split into sections using viper's prefix functionality, making toml more readable

Flag priority on run is:
1. CLI specified flags: ./binary --flag=value 
2. Toml. Anything the user writes in the toml
3. Default values. If the user choses to clean up the toml and delete flags that they don't want to change, viper will read the default value from the flags.go initialization