### PR TITLE
Zero address is now a context-dependent function for ETX processing

### DIFF
--- a/common/main_test.go
+++ b/common/main_test.go
@@ -3,13 +3,11 @@ package common
 import (
 	"os"
 	"testing"
-
-	"github.com/dominant-strategies/go-quai/log"
 )
 
 func TestMain(m *testing.M) {
 	// Comment / un comment below to see log output while testing
-	log.ConfigureLogger(log.WithNullLogger())
+	// log.ConfigureLogger(log.WithNullLogger())
 	// log.ConfigureLogger(log.WithLevel("debug"))
 	os.Exit(m.Run())
 }

--- a/common/types.go
+++ b/common/types.go
@@ -55,8 +55,8 @@ const (
 var (
 	hashT = reflect.TypeOf(Hash{})
 	// The zero address (0x0)
-	ZeroInternal    = InternalAddress{}
-	ZeroAddr        = Address{&ZeroInternal}
+	ZeroExternal    = ExternalAddress{}
+	Zero            = Address{&ZeroExternal} // For utility purposes only. It is out-of-scope for state purposes.
 	ErrInvalidScope = errors.New("address is not in scope")
 )
 
@@ -509,8 +509,7 @@ func IsInChainScope(b []byte, nodeLocation Location) bool {
 	if nodeCtx != ZONE_CTX {
 		return false
 	}
-	// TODO: this shouldn't happen. The zero address should not be special. Each chain may use its own zero address.
-	if BytesToHash(b) == ZeroAddr.Hash() {
+	if BytesToHash(b) == ZeroAddress(nodeLocation).Hash() {
 		return true
 	}
 	return b[0] == nodeLocation.BytePrefix()
@@ -527,4 +526,13 @@ func OrderToString(order int) string {
 	default:
 		return "Invalid"
 	}
+}
+
+func ZeroInternal(nodeLocation Location) InternalAddress {
+	return InternalAddress{nodeLocation.BytePrefix()}
+}
+
+func ZeroAddress(nodeLocation Location) Address {
+	internal := InternalAddress{nodeLocation.BytePrefix()}
+	return Address{&internal}
 }

--- a/common/types_test.go
+++ b/common/types_test.go
@@ -27,6 +27,8 @@ import (
 	"testing"
 )
 
+var nodeLocation = Location{1, 1}
+
 func TestBytesConversion(t *testing.T) {
 	bytes := []byte{5}
 	hash := BytesToHash(bytes)
@@ -139,7 +141,7 @@ func TestAddressHexChecksum(t *testing.T) {
 		{"0x000000000000000000000000000000000000000a", "0x000000000000000000000000000000000000000A"},
 	}
 	for i, test := range tests {
-		output := HexToAddress(test.Input).Hex()
+		output := HexToAddress(test.Input, nodeLocation).Hex()
 		if output != test.Output {
 			t.Errorf("test #%d: failed to match when it should (%s != %s)", i, output, test.Output)
 		}
@@ -147,7 +149,7 @@ func TestAddressHexChecksum(t *testing.T) {
 }
 
 func BenchmarkAddressHex(b *testing.B) {
-	testAddr := HexToAddress("0x5aaeb6053f3e94c9b9a09f33669435e7ef1beaed")
+	testAddr := HexToAddress("0x5aaeb6053f3e94c9b9a09f33669435e7ef1beaed", nodeLocation)
 	for n := 0; n < b.N; n++ {
 		testAddr.Hex()
 	}
@@ -343,7 +345,7 @@ func TestAddress_Value(t *testing.T) {
 		0xb2, 0x6f, 0x2b, 0x34, 0x2a, 0xab, 0x24, 0xbc, 0xf6, 0x3e,
 		0xa2, 0x18, 0xc6, 0xa9, 0x27, 0x4d, 0x30, 0xab, 0x9a, 0x15,
 	}
-	usedA := BytesToAddress(b);
+	usedA := BytesToAddress(b, nodeLocation)
 	tests := []struct {
 		name    string
 		a       Address
@@ -377,7 +379,7 @@ func TestAddress_Format(t *testing.T) {
 		0xa2, 0x18, 0xc6, 0xa9, 0x27, 0x4d, 0x30, 0xab, 0x9a, 0x15,
 	}
 
-	addr := BytesToAddress(b)
+	addr := BytesToAddress(b, nodeLocation)
 	tests := []struct {
 		name string
 		out  string
@@ -531,5 +533,16 @@ func TestHash_Format(t *testing.T) {
 				t.Errorf("%s does not render as expected:\n got %s\nwant %s", tt.name, tt.out, tt.want)
 			}
 		})
+	}
+}
+
+func TestZeroAddress(t *testing.T) {
+	t.Log(ZeroAddress(nodeLocation).String())
+	internal, err := ZeroAddress(nodeLocation).InternalAddress()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if internal.String() != "0x1100000000000000000000000000000000000000" {
+		t.Fatal("wrong internal address, expected 0x1100000000000000000000000000000000000000")
 	}
 }

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -102,7 +102,7 @@ func (b *BlockGen) AddTx(tx *types.Transaction, etxRLimit, etxPLimit *int) {
 // the block in chain will be returned.
 func (b *BlockGen) AddTxWithChain(hc *HeaderChain, tx *types.Transaction, etxRLimit, etxPLimit *int) {
 	if b.gasPool == nil {
-		b.SetCoinbase(common.Address{})
+		b.SetCoinbase(common.ZeroAddress(hc.config.Location))
 	}
 	b.statedb.Prepare(tx.Hash(), len(b.txs))
 	coinbase := b.header.Coinbase()

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -267,7 +267,9 @@ func (g *Genesis) ToBlock(db ethdb.Database) *types.Block {
 	head.SetTime(g.Timestamp)
 	head.SetExtra(g.ExtraData)
 	head.SetDifficulty(g.Difficulty)
-	head.SetCoinbase(common.ZeroAddr)
+	if g.Config.Location.Context() == common.ZONE_CTX {
+		head.SetCoinbase(common.ZeroAddress(g.Config.Location))
+	}
 	head.SetGasLimit(g.GasLimit)
 	head.SetGasUsed(0)
 	head.SetBaseFee(new(big.Int).SetUint64(params.InitialBaseFee))

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -192,7 +192,7 @@ func ApplyMessage(evm *vm.EVM, msg Message, gp *GasPool) (*ExecutionResult, erro
 // to returns the recipient of the message.
 func (st *StateTransition) to() common.Address {
 	if st.msg == nil || st.msg.To() == nil /* contract creation */ {
-		return common.ZeroAddr
+		return common.ZeroAddress(st.evm.ChainConfig().Location)
 	}
 	return *st.msg.To()
 }
@@ -299,7 +299,7 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 	}
 	msg := st.msg
 	sender := vm.AccountRef(msg.From())
-	contractCreation := msg.To() == nil
+	contractCreation := msg.To() == nil // for ETX contract creation, perhaps we should compare the "to" to the contextual zero-address (only in the ETX case)
 
 	// Check clauses 4-5, subtract intrinsic gas if everything is correct
 	gas, err := IntrinsicGas(st.data, st.msg.AccessList(), contractCreation)

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -913,7 +913,7 @@ func (tx *Transaction) AsMessage(s Signer, baseFee *big.Int) (Message, error) {
 	}
 	var err error
 	if tx.Type() == ExternalTxType {
-		msg.from = common.ZeroAddr
+		msg.from = common.ZeroAddress(s.Location())
 		msg.etxsender, err = Sender(s, tx)
 		msg.checkNonce = false
 	} else {
@@ -950,7 +950,7 @@ func (tx *Transaction) AsMessageWithSender(s Signer, baseFee *big.Int, sender *c
 	}
 	var err error
 	if tx.Type() == ExternalTxType {
-		msg.from = common.ZeroAddr
+		msg.from = common.ZeroAddress(s.Location())
 		msg.etxsender, err = Sender(s, tx)
 		msg.checkNonce = false
 	} else {

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -404,7 +404,7 @@ func (c *codeAndHash) Hash() common.Hash {
 func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64, value *big.Int, address common.Address) ([]byte, common.Address, uint64, error) {
 	internalCallerAddr, err := caller.Address().InternalAddress()
 	if err != nil {
-		return nil, common.ZeroAddr, 0, err
+		return nil, common.Zero, 0, err
 	}
 	nonce := evm.StateDB.GetNonce(internalCallerAddr)
 	evm.StateDB.SetNonce(internalCallerAddr, nonce+1)
@@ -412,15 +412,15 @@ func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64,
 	// Depth check execution. Fail if we're trying to execute above the
 	// limit.
 	if evm.depth > int(params.CallCreateDepth) {
-		return nil, common.ZeroAddr, gas, ErrDepth
+		return nil, common.Zero, gas, ErrDepth
 	}
 	if !evm.Context.CanTransfer(evm.StateDB, caller.Address(), value) {
-		return nil, common.ZeroAddr, gas, ErrInsufficientBalance
+		return nil, common.Zero, gas, ErrInsufficientBalance
 	}
 
 	internalContractAddr, err := address.InternalAddress()
 	if err != nil {
-		return nil, common.ZeroAddr, 0, err
+		return nil, common.Zero, 0, err
 	}
 
 	// We add this to the access list _before_ taking a snapshot. Even if the creation fails,
@@ -430,7 +430,7 @@ func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64,
 	// Ensure there's no existing contract already at the designated address
 	contractHash := evm.StateDB.GetCodeHash(internalContractAddr)
 	if evm.StateDB.GetNonce(internalContractAddr) != 0 || (contractHash != (common.Hash{}) && contractHash != emptyCodeHash) {
-		return nil, common.ZeroAddr, 0, ErrContractAddressCollision
+		return nil, common.Zero, 0, ErrContractAddressCollision
 	}
 	// Create a new account on the state
 	snapshot := evm.StateDB.Snapshot()
@@ -439,7 +439,7 @@ func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64,
 	evm.StateDB.SetNonce(internalContractAddr, 1)
 
 	if err := evm.Context.Transfer(evm.StateDB, caller.Address(), address, value); err != nil {
-		return nil, common.ZeroAddr, 0, err
+		return nil, common.Zero, 0, err
 	}
 
 	// Initialise a new contract and set the code that is to be used by the EVM.
@@ -501,7 +501,7 @@ func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64,
 func (evm *EVM) Create(caller ContractRef, code []byte, gas uint64, value *big.Int) (ret []byte, contractAddr common.Address, leftOverGas uint64, err error) {
 	internalAddr, err := caller.Address().InternalAddress()
 	if err != nil {
-		return nil, common.ZeroAddr, 0, err
+		return nil, common.Zero, 0, err
 	}
 
 	nonce := evm.StateDB.GetNonce(internalAddr)
@@ -514,13 +514,13 @@ func (evm *EVM) Create(caller ContractRef, code []byte, gas uint64, value *big.I
 	// Calculate the gas required for the keccak256 computation of the input data.
 	gasCost, err := calculateKeccakGas(code)
 	if err != nil {
-		return nil, common.ZeroAddr, 0, err
+		return nil, common.Zero, 0, err
 	}
 
 	// attempt to grind the address
 	contractAddr, remainingGas, err := evm.attemptGrindContractCreation(caller, nonce, gas, gasCost, code)
 	if err != nil {
-		return nil, common.ZeroAddr, 0, err
+		return nil, common.Zero, 0, err
 	}
 
 	gas = remainingGas
@@ -552,7 +552,7 @@ func (evm *EVM) attemptGrindContractCreation(caller ContractRef, nonce uint64, g
 
 		// Check if there is enough gas left to continue.
 		if gas < uint64(gasCost) {
-			return common.ZeroAddr, 0, fmt.Errorf("out of gas grinding contract address for %v", caller.Address().Hex())
+			return common.Zero, 0, fmt.Errorf("out of gas grinding contract address for %v", caller.Address().Hex())
 		}
 
 		// Subtract the gas cost for each attempt.
@@ -570,7 +570,7 @@ func (evm *EVM) attemptGrindContractCreation(caller ContractRef, nonce uint64, g
 		}
 	}
 	// Return an error if a valid address could not be found after the maximum number of attempts.
-	return common.ZeroAddr, 0, fmt.Errorf("exceeded number of attempts grinding address %v", caller.Address().Hex())
+	return common.Zero, 0, fmt.Errorf("exceeded number of attempts grinding address %v", caller.Address().Hex())
 }
 
 // Create2 creates a new contract using code as deployment code.

--- a/core/worker.go
+++ b/core/worker.go
@@ -526,7 +526,7 @@ func (w *worker) GeneratePendingHeader(block *types.Block, fill bool) (*types.He
 	start := time.Now()
 	// Set the coinbase if the worker is running or it's required
 	var coinbase common.Address
-	if w.coinbase.Equal(common.ZeroAddr) {
+	if w.coinbase.Equal(common.Zero) {
 		w.logger.Error("Refusing to mine without etherbase")
 		return nil, errors.New("etherbase not found")
 	}
@@ -891,7 +891,7 @@ func (w *worker) prepareWork(genParams *generateParams, block *types.Block) (*en
 		header.SetExtra(w.extra)
 		header.SetBaseFee(misc.CalcBaseFee(w.chainConfig, parent.Header()))
 		if w.isRunning() {
-			if w.coinbase.Equal(common.ZeroAddr) {
+			if w.coinbase.Equal(common.Zero) {
 				w.logger.Error("Refusing to mine without etherbase")
 				return nil, errors.New("refusing to mine without etherbase")
 			}

--- a/quai/backend.go
+++ b/quai/backend.go
@@ -317,11 +317,11 @@ func (s *Quai) Etherbase() (eb common.Address, err error) {
 	etherbase := s.etherbase
 	s.lock.RUnlock()
 
-	if !etherbase.Equal(common.ZeroAddr) {
+	if !etherbase.Equal(common.Zero) {
 		return etherbase, nil
 	}
 
-	return common.ZeroAddr, fmt.Errorf("etherbase must be explicitly specified")
+	return common.Zero, fmt.Errorf("etherbase must be explicitly specified")
 }
 
 // isLocalBlock checks whether the specified block is mined

--- a/quaiclient/ethclient/ethclient.go
+++ b/quaiclient/ethclient/ethclient.go
@@ -265,10 +265,10 @@ func (ec *Client) TransactionSender(ctx context.Context, tx *types.Transaction, 
 		From common.Address
 	}
 	if err = ec.c.CallContext(ctx, &meta, "eth_getTransactionByBlockHashAndIndex", block, hexutil.Uint64(index)); err != nil {
-		return common.ZeroAddr, err
+		return common.Zero, err
 	}
 	if meta.Hash == (common.Hash{}) || meta.Hash != tx.Hash() {
-		return common.ZeroAddr, errors.New("wrong inclusion block/index")
+		return common.Zero, errors.New("wrong inclusion block/index")
 	}
 	return meta.From, nil
 }

--- a/quaiclient/ethclient/signer.go
+++ b/quaiclient/ethclient/signer.go
@@ -46,7 +46,7 @@ func (s *senderFromServer) Equal(other types.Signer) bool {
 
 func (s *senderFromServer) Sender(tx *types.Transaction) (common.Address, error) {
 	if s.blockhash == (common.Hash{}) {
-		return common.ZeroAddr, errNotCached
+		return common.Zero, errNotCached
 	}
 	return s.addr, nil
 }
@@ -58,5 +58,9 @@ func (s *senderFromServer) Hash(tx *types.Transaction) common.Hash {
 	panic("can't sign with senderFromServer")
 }
 func (s *senderFromServer) SignatureValues(tx *types.Transaction, sig []byte) (R, S, V *big.Int, err error) {
+	panic("can't sign with senderFromServer")
+}
+
+func (s *senderFromServer) Location() common.Location {
 	panic("can't sign with senderFromServer")
 }


### PR DESCRIPTION
ETXs are spent from the "zero" address. The "zero" address is computed by placing the node location byte prefix at the front of the address and padding the other 19 bytes with zeroes. This complies with QIP2. This is only for the Quai account address space; currently there is no "zero" address for the Qi UTXO address space, although the same approach could be taken with bit 9 as 1. 
To allow for ETX contract creation, we can add a check in the ETX case for the "to" address being a contextual "zero" address and enable contract creation in that case. That is not done in this PR.