### PR TITLE
ETX contract deployment

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -316,8 +316,12 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 
 	msg := st.msg
 	sender := vm.AccountRef(msg.From())
-	contractCreation := msg.To() == nil // for ETX contract creation, perhaps we should compare the "to" to the contextual zero-address (only in the ETX case)
-
+	contractCreation := msg.To() == nil
+	if st.msg.IsETX() {
+		// for ETX contract creation, we compare the "to" to the contextual zero-address (only in the ETX case)
+		// the "from" is also set to the contextual zero-address, so it will look like a transaction from the zero-address to itself
+		contractCreation = msg.To().Equal(common.ZeroAddress(st.evm.ChainConfig().Location))
+	}
 	// Check clauses 4-5, subtract intrinsic gas if everything is correct
 	gas, err := IntrinsicGas(st.data, st.msg.AccessList(), contractCreation)
 	if err != nil {


### PR DESCRIPTION
ETXs can now deploy smart contracts by adding a smart contract to the ETXData field (in InternalToExternal tx) and setting the To field to the destination chain's contextual "zero" address. The "zero" address is computed by placing the destination location byte prefix at the front of the address and padding the other 19 bytes with zeroes. This PR builds upon changes made in https://github.com/dominant-strategies/go-quai-libp2p/pull/60 and fixes https://github.com/dominant-strategies/go-quai/issues/1313

Edit: Tested by deploying a contract with internal to external tx from zone-0-0 to zone-0-1, contract deployed successfully and I was able to query the state of the contract.