### PR TITLE
Improve peer request ordering

### DIFF
--- a/p2p/peerManager/peerManager.go
+++ b/p2p/peerManager/peerManager.go
@@ -159,8 +159,13 @@ func (pm *BasicPeerManager) MarkLatentPeer(peer p2p.PeerID) {
 }
 
 func (pm *BasicPeerManager) calculatePeerLiveness(peer p2p.PeerID) float64 {
-	liveness := pm.GetTagInfo(peer).Tags["liveness_reports"]
-	latents := pm.GetTagInfo(peer).Tags["latency_reports"]
+	peerTag := pm.GetTagInfo(peer)
+	if peerTag == nil {
+		return 0
+	}
+
+	liveness := peerTag.Tags["liveness_reports"]
+	latents := peerTag.Tags["latency_reports"]
 	return float64(liveness) / float64(latents)
 }
 
@@ -175,8 +180,12 @@ func (pm *BasicPeerManager) MarkUnresponsivePeer(peer p2p.PeerID) {
 }
 
 func (pm *BasicPeerManager) calculatePeerResponsiveness(peer p2p.PeerID) float64 {
-	responses := pm.GetTagInfo(peer).Tags["responses_served"]
-	misses := pm.GetTagInfo(peer).Tags["responses_missed"]
+	peerTag := pm.GetTagInfo(peer)
+	if peerTag == nil {
+		return 0
+	}
+	responses := peerTag.Tags["responses_served"]
+	misses := peerTag.Tags["responses_missed"]
 	return float64(responses) / float64(misses)
 }
 

--- a/p2p/peerManager/peerManager.go
+++ b/p2p/peerManager/peerManager.go
@@ -90,6 +90,10 @@ func NewManager(low int, high int, datastore datastore.Datastore) (*BasicPeerMan
 	return &BasicPeerManager{
 		BasicConnMgr:         mgr,
 		BasicConnectionGater: gater,
+
+		bestPeers:       make(map[peer.ID]struct{}),
+		responsivePeers: make(map[peer.ID]struct{}),
+		peers:           make(map[peer.ID]struct{}),
 	}, nil
 }
 


### PR DESCRIPTION
Previously we would go ahead and hit the DHT with our request before we gave our peers a chance to respond. Now we ask the peers first, and only if that fails do we go to the DHT