### PR TITLE
Implement custom propagation hooks to prevent bad data from spreading

### DIFF
--- a/common/stream_services.go
+++ b/common/stream_services.go
@@ -40,17 +40,15 @@ func WriteMessageToStream(stream network.Stream, msg []byte) error {
 		return errors.Wrap(err, "failed to set write deadline")
 	}
 
-	// Get the length of the message and convert it into 4 bytes
+	// Get the length of the message and encode it
 	msgLen := uint32(len(msg))
 	lenBytes := make([]byte, 4)
 	binary.BigEndian.PutUint32(lenBytes, msgLen)
 
-	// First write the length of the message
-	if _, err := stream.Write(lenBytes); err != nil {
-		return errors.Wrap(err, "failed to write message length to stream")
-	}
+	// Prefix the message with the encoded length
+	msg = append(lenBytes, msg...)
 
-	// Then write the message itself
+	// Then write the message
 	_, err := stream.Write(msg)
 	if err != nil {
 		return errors.Wrap(err, "failed to write message to stream")

--- a/consensus/misc/rewards.go
+++ b/consensus/misc/rewards.go
@@ -36,25 +36,8 @@ func calculateQiReward(header *types.Header) *big.Int {
 	return big.NewInt(1000)
 }
 
-func CalculateRewardForQi(header *types.Header) map[uint8]uint8 {
-	rewardFromDifficulty := new(big.Int).Add(types.Denominations[types.MaxDenomination], types.Denominations[10])
-	return findMinDenominations(rewardFromDifficulty)
-}
-
-func CalculateRewardForQiWithFees(header *types.Header, fees *big.Int) map[uint8]uint8 {
-	rewardFromDifficulty := new(big.Int).Add(types.Denominations[types.MaxDenomination], types.Denominations[10])
-	reward := new(big.Int).Add(rewardFromDifficulty, fees)
-	return findMinDenominations(reward)
-}
-
-func CalculateRewardForQiWithFeesBigInt(header *types.Header, fees *big.Int) *big.Int {
-	rewardFromDifficulty := new(big.Int).Add(types.Denominations[types.MaxDenomination], types.Denominations[10])
-	reward := new(big.Int).Add(rewardFromDifficulty, fees)
-	return reward
-}
-
-// findMinDenominations finds the minimum number of denominations to make up the reward
-func findMinDenominations(reward *big.Int) map[uint8]uint8 {
+// FindMinDenominations finds the minimum number of denominations to make up the reward
+func FindMinDenominations(reward *big.Int) map[uint8]uint8 {
 	// Store the count of each denomination used (map denomination to count)
 	denominationCount := make(map[uint8]uint8)
 	amount := new(big.Int).Set(reward)

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -1040,6 +1040,10 @@ func (pool *TxPool) addTxs(txs []*types.Transaction, local, sync bool) []error {
 				errs[i] = err
 			}
 			continue
+		} else if tx.Type() == types.InternalToExternalTxType && tx.To() == nil {
+			errs[i] = errors.New("to address is nil in InternalToExternalTx") // remove this check when InternalToExternalTx is removed
+			invalidTxMeter.Add(1)
+			continue
 		}
 		if tx.To().IsInQiLedgerScope() {
 			errs[i] = common.MakeErrQiAddress(tx.To().Hex())
@@ -1069,12 +1073,6 @@ func (pool *TxPool) addTxs(txs []*types.Transaction, local, sync bool) []error {
 			_, err = from.InternalAndQuaiAddress()
 			if err != nil {
 				errs[i] = err
-				invalidTxMeter.Add(1)
-				continue
-			}
-			_, err = types.Sender(pool.signer, tx)
-			if err != nil {
-				errs[i] = ErrInvalidSender
 				invalidTxMeter.Add(1)
 				continue
 			}

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -1140,7 +1140,7 @@ func (b *Block) QiTransactions() []*Transaction {
 func (b *Block) QuaiTransactions() []*Transaction {
 	quaiTxs := make([]*Transaction, 0)
 	for _, t := range b.Transactions() {
-		if t.Type() != QiTxType && t.To().IsInQuaiLedgerScope() {
+		if t.Type() != QiTxType && (t.To() == nil || t.To().IsInQuaiLedgerScope()) {
 			quaiTxs = append(quaiTxs, t)
 		}
 	}

--- a/core/types/qi_tx.go
+++ b/core/types/qi_tx.go
@@ -23,11 +23,6 @@ type WireQiTx struct {
 	Signature []byte
 }
 
-type QiTxWithMinerFee struct {
-	Tx  *Transaction
-	Fee *big.Int
-}
-
 // copy creates a deep copy of the transaction data and initializes all fields.
 func (tx *QiTx) copy() TxData {
 	cpy := &QiTx{

--- a/internal/quaiapi/api.go
+++ b/internal/quaiapi/api.go
@@ -1563,7 +1563,7 @@ func (s *PublicTransactionPoolAPI) SendRawTransaction(ctx context.Context, input
 		return common.Hash{}, err
 	}
 	if tx.Type() != types.QiTxType {
-		if tx.To().IsInQiLedgerScope() { // change after adding Quai->Qi conversion tx type
+		if tx.To() != nil && tx.To().IsInQiLedgerScope() { // change after adding Quai->Qi conversion tx type
 			return common.Hash{}, common.MakeErrQiAddress(tx.To().Hex())
 		}
 	}

--- a/internal/quaiapi/quai_api.go
+++ b/internal/quaiapi/quai_api.go
@@ -30,6 +30,7 @@ import (
 	"github.com/dominant-strategies/go-quai/core/types"
 	"github.com/dominant-strategies/go-quai/crypto"
 	"github.com/dominant-strategies/go-quai/log"
+	"github.com/dominant-strategies/go-quai/params"
 	"github.com/dominant-strategies/go-quai/rpc"
 	"github.com/dominant-strategies/go-quai/trie"
 )
@@ -445,7 +446,14 @@ func (s *PublicBlockChainQuaiAPI) EstimateGas(ctx context.Context, args Transact
 	switch args.TxType {
 	case types.QiTxType:
 		return args.CalculateQiTxGas()
-	case types.InternalTxType, types.ExternalTxType, types.InternalToExternalTxType:
+	case types.InternalToExternalTxType:
+		if args.To == nil {
+			return 0, errors.New("to address is required for internal to external transaction")
+		} else if _, err := args.To.InternalAndQuaiAddress(); err != nil {
+			return 0, err
+		}
+		return hexutil.Uint64(params.TxGas + params.ETXGas), nil
+	case types.InternalTxType:
 		return DoEstimateGas(ctx, s.b, args, bNrOrHash, s.b.RPCGasCap())
 	default:
 		return 0, errors.New("unsupported tx type")

--- a/p2p/node/api.go
+++ b/p2p/node/api.go
@@ -65,6 +65,7 @@ func (p *P2PNode) Broadcast(location common.Location, data interface{}) error {
 
 func (p *P2PNode) SetConsensusBackend(be quai.ConsensusAPI) {
 	p.consensus = be
+	p.pubsub.SetQuaiBackend(be)
 }
 
 type stopFunc func() error

--- a/p2p/protocol/interface.go
+++ b/p2p/protocol/interface.go
@@ -4,8 +4,8 @@ import (
 	"math/big"
 
 	"github.com/libp2p/go-libp2p/core/host"
-	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/core/peer"
 
 	"github.com/dominant-strategies/go-quai/common"
 	"github.com/dominant-strategies/go-quai/core/types"

--- a/quai/interface.go
+++ b/quai/interface.go
@@ -1,13 +1,16 @@
 package quai
 
 import (
+	"context"
 	"math/big"
 
 	"github.com/dominant-strategies/go-quai/common"
 	"github.com/dominant-strategies/go-quai/core/types"
 
 	"github.com/dominant-strategies/go-quai/trie"
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/libp2p/go-libp2p/core"
+	"github.com/libp2p/go-libp2p/core/peer"
 )
 
 // The consensus backend will implement the following interface to provide information to the networking backend.
@@ -19,6 +22,9 @@ type ConsensusAPI interface {
 	// Specify the peer which propagated the data to us, as well as the data itself.
 	// Return true if this data should be relayed to peers. False if it should be ignored.
 	OnNewBroadcast(core.PeerID, interface{}, common.Location) bool
+
+	// Creates the function that will be used to determine if a message should be propagated.
+	ValidatorFunc() func(ctx context.Context, id peer.ID, msg *pubsub.Message) pubsub.ValidationResult
 
 	// Asks the consensus backend to lookup a block by hash and location.
 	// If the block is found, it should be returned. Otherwise, nil should be returned.

--- a/quai/p2p_backend.go
+++ b/quai/p2p_backend.go
@@ -11,6 +11,8 @@ import (
 	"github.com/dominant-strategies/go-quai/p2p"
 	"github.com/dominant-strategies/go-quai/rpc"
 	"github.com/dominant-strategies/go-quai/trie"
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	"github.com/libp2p/go-libp2p/core/peer"
 )
 
 // QuaiBackend implements the quai consensus protocol
@@ -112,6 +114,29 @@ func (qbe *QuaiBackend) GetTrieNode(hash common.Hash, location common.Location) 
 func (qbe *QuaiBackend) GetHeight(location common.Location) uint64 {
 	// Example/mock implementation
 	panic("todo")
+}
+
+func (qbe *QuaiBackend) ValidatorFunc() func(ctx context.Context, id p2p.PeerID, msg *pubsub.Message) pubsub.ValidationResult {
+	return func(ctx context.Context, id peer.ID, msg *pubsub.Message) pubsub.ValidationResult {
+		var data interface{}
+		data = msg.Message.GetData()
+		switch data.(type) {
+		case types.Block:
+			block := data.(types.Block)
+			backend := *qbe.GetBackend(block.Location())
+			if backend == nil {
+				log.Global.WithFields(log.Fields{
+					"peer":     id,
+					"hash":     block.Hash(),
+					"location": block.Location(),
+				}).Error("no backend found for this location")
+				return pubsub.ValidationReject
+			}
+		case types.Transaction:
+			return pubsub.ValidationAccept
+		}
+		return pubsub.ValidationAccept
+	}
 }
 
 func (qbe *QuaiBackend) LookupBlock(hash common.Hash, location common.Location) *types.Block {


### PR DESCRIPTION
These are stubs for validation of:
- blocks
- transactions
Anything that gets ValidationReject will not only not re-propagate to peers, but will also not be sent to consensus. Suggest quick validation of things without excessive processing.